### PR TITLE
Update funding docs with minimal phase I/II wording

### DIFF
--- a/finance/funding_requests.md
+++ b/finance/funding_requests.md
@@ -40,9 +40,9 @@ Payment will be made to you directly from  NumFOCUS, typically within 30 days af
  and potential new contributors to propose ideas for funding by the
  Astropy community but this requires time to develop a process for
  balancing different priorities for limited funding.  In 2020, funding
- a fixed amount of funding, not based on numbers of hours worked, was offered to current astropy maintainers and no more funding is
+ a fixed amount of funding, not based on numbers of hours worked, was offered to current Astropy maintainers and no more funding is
  available for the 2019-2020 budget year. In later years, the funding
- will be distributed in other ways, and the interim finance committee
+ will be distributed in other ways, and the Interim Finance Committee
  is working out a fair and open process. The committee welcomes input
  on project goals and processes that should be funded.*
 

--- a/finance/funding_requests.md
+++ b/finance/funding_requests.md
@@ -36,7 +36,18 @@ Payment will be made to you directly from  NumFOCUS, typically within 30 days af
 
 ## Contract Work
 
-*Our intent is to build this into a process that allows both existing and potential new contributors to propose ideas for funding by the Astropy community but this requires time to develop a process for balancing different priorities for limited funding. In its current form, this document describes how the process has been handled in the past, when funding was available only through specific grants for very well defined tasks, so it will be used only for existing contributors who require support for priorities already identified by the Astropy Coordination Committee (as charged by the participants of the 2019 coordination meeting).* 
+*Our intent is to build this into a process that allows both existing
+ and potential new contributors to propose ideas for funding by the
+ Astropy community but this requires time to develop a process for
+ balancing different priorities for limited funding.  In 2020, funding
+ was offered to current astropy team members and no more funding is
+ available for the 2019-2020 budget year. In later years, the funding
+ will be distributed in other ways, and the interim finance committee
+ is working out a fair and open process. The committee welcomes input
+ on project goals and processes that should be funded.*
+
+The text below describes how the current contracts were handled and
+how current contractors should report expenses and invoices.
 
 ### Contracts
 To request a contract send an email to finance@astropy.org with the subject line "Request for Contract" and include the following information:

--- a/finance/funding_requests.md
+++ b/finance/funding_requests.md
@@ -40,7 +40,7 @@ Payment will be made to you directly from  NumFOCUS, typically within 30 days af
  and potential new contributors to propose ideas for funding by the
  Astropy community but this requires time to develop a process for
  balancing different priorities for limited funding.  In 2020, funding
- was offered to current astropy team members and no more funding is
+ a fixed amount of funding, not based on numbers of hours worked, was offered to current astropy maintainers and no more funding is
  available for the 2019-2020 budget year. In later years, the funding
  will be distributed in other ways, and the interim finance committee
  is working out a fair and open process. The committee welcomes input


### PR DESCRIPTION
The goal of this update is not to describe phase II of distributing
Moore funding in detail (since we don't yet know how that will be done),
but just to put a word of caution in the offical, publically
visible funding process to prevent disappointent from
people reading this, applying according to this process, and
not reveiving funding in the end.